### PR TITLE
Add flash unprotect command

### DIFF
--- a/src/flash.rs
+++ b/src/flash.rs
@@ -118,6 +118,16 @@ impl Flash {
         self.command(Command::Reset)
     }
 
+    /// Unprotect the flash memory
+    pub fn unprotect(&mut self) -> Result<()> {
+        let status1 = self.read_status1()?;
+        let status2 = self.read_status2()?;
+        let new_status1 = status1 & 0b11100011;
+        self.write_enable()?;
+        self.write_status(new_status1, status2)?;
+        Ok(())
+    }
+
     /// Power down the attached flash
     pub fn power_down(&mut self) -> Result<()> {
         self.command(Command::PowerDown)
@@ -217,6 +227,10 @@ impl Flash {
 
     fn read_status1(&mut self) -> Result<u8> {
         self.exchange(Command::ReadStatusRegister1, &[], 1).map(|data| data[0])
+    }
+
+    fn write_status(&mut self, status1: u8, status2: u8) -> Result<()> {
+        self.write(Command::WriteStatusRegister, &[status1, status2])
     }
 
     #[allow(dead_code)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,9 @@ fn main() -> anyhow::Result<()> {
                      .help("Start address (in bytes) of read")
                      .long("offset")
                      .takes_value(true)
-                     .default_value("0"))))
+                     .default_value("0")))
+            .subcommand(SubCommand::with_name("unprotect")
+                .about("Unprotect SPI flash")))
         .get_matches();
 
     pretty_env_logger::init();
@@ -257,6 +259,11 @@ fn main() -> anyhow::Result<()> {
                     file.write_all(&data)?;
                     if !quiet { println!("Flash read.") };
                 },
+                Some("unprotect") => {
+                    if !quiet { println!("Disabling flash write protection...") };
+                    flash.unprotect()?;
+                    if !quiet { println!("Flash protected disabled.") };
+                }
                 _ => panic!("Unhandled flash subcommand."),
             }
         },


### PR DESCRIPTION
This command is useful for Colorlight i5 as it has a flash chip write protected out of the box.