### PR TITLE
Add notes on OSX Big Sur

### DIFF
--- a/drivers/README.md
+++ b/drivers/README.md
@@ -31,5 +31,8 @@ allowing ECPDAP to use the device.
 
 ## MacOS
 
-No information for MacOS is known at present. If you are using MacOS, please
-consider updating this file.
+Install libusb-compat via Homebrew:
+```
+brew install libusb-compat 
+```
+Confirmed working under MacOS 11.4 Big Sur


### PR DESCRIPTION
Under OSX Big Sur (11.4) a libusb compat driver may be installed via homebrew.
I can successfully probe and scan after doing this:
````
% sw_vers -productVersion 
11.4
% ecpdap probes           
Found 1 CMSIS-DAP probe:
  0d28:0204:0700000105d8ff383939534743076224a5a5a5a597969908 DAPLink CMSIS-DAP
% ecpdap scan  
Detected JTAG chain, closest to TDO first:
 - 0: 0x41111043 (Lattice Semi.) [IR length: 8] [LFE5U-25]
 ````
